### PR TITLE
add env hook to dynamicaly get version string

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -e
 
+. ./hooks/env
+
 # $IMAGE_NAME var is injected into the build so the tag is correct.
 
 echo "Build hook running"
 docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg VCS_REF=`git rev-parse --short HEAD` \
-             --build-arg VERSION="4.3.1" \
+             --build-arg VERSION="$rel_ver" \
              -t $IMAGE_NAME .

--- a/hooks/env
+++ b/hooks/env
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Get the sem-ver of the latest stable release for tagging
+rel_ver="$(git ls-remote --refs --tags --sort=v:refname git://github.com/eXist-db/exist.git  | awk '{print $2}' | awk -F"/" '{print $3}' | grep -r '^eXist-[0-9]\+\.[0-9]\+\.[0-9]\+$' | tail -n 1 | cut -d \- -f 2)"

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,13 +1,15 @@
 #!/bin/bash
-
 set -e
+
+. ./hooks/env
 
 # Parse image name for repo name
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
+
 # Tag and push image for each additional tag
-for tag in {4.3.1,release}; do
+for tag in {$rel_ver,release}; do
     docker tag $IMAGE_NAME ${repoName}:${tag}
     docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
With this PR tags for full releases are no longer hard-coded, but created dynamically. 
We could do something similar for the develop branch if we had a tag that would indicate the current SNAPSHOT version there. 
This  does not cover RCs on purpose. The docker build procedures between major versions is not always compatible 
see #14

Please just add your review comments, i need to disable some stuff on dockerhub to make sure it works as expected there as well as here. So if you guys are ok with the changes, i ll do that and then merge myself, to ensure all is peachy. 