### PR TITLE
auto tagging works now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM openjdk:8-jdk-alpine as builder
 
-# arguments can be referenced at build time chose master for the stable release channel
+# BRANCH takes any valid git ref as build-arg chose master for stable releases and develop for latest
 ARG BRANCH=master
 
 # ENV for builder
@@ -31,11 +31,11 @@ FROM openjdk:8-jdk-slim as jdk
 RUN sed -i "s|^assistive_technologies|#assistive_technologies|" /etc/java-8-openjdk/accessibility.properties
 
 FROM gcr.io/distroless/java:latest
-
+# exist to jvm configuration options need to be accessible at build time to be effective
 ARG CACHE_MEM
 ARG MAX_BROKER
 
-# Build-time metadata as defined at http://label-schema.org
+# Build-time metadata as defined at http://label-schema.org (and used by autobuilder)
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION="4.3.1"
@@ -91,7 +91,7 @@ ADD ./src/log4j2.xml .
 # ADD ./src/exist-webapp-context.xml ./tools/jetty/webapps/
 # ADD ./src/controller-config.xml ./webapp/WEB-INF/controller-config.xml
 
-# Configure JVM for us in container (here there be dragons)
+# Configure JVM for use in container (here there be dragons)
 ENV JAVA_TOOL_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XX:+UseG1GC -XX:+UseStringDeduplication -Dfile.encoding=UTF8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20}
 
 # Port configuration

--- a/hooks/build
+++ b/hooks/build
@@ -1,12 +1,14 @@
 #!/bin/bash
-set -e
+set -xe
+
+# see https://docs.docker.com/docker-cloud/builds/advanced/
 
 . ./hooks/env
 
 # $IMAGE_NAME var is injected into the build so the tag is correct.
 
 echo "Build hook running"
-docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-             --build-arg VCS_REF=`git rev-parse --short HEAD` \
-             --build-arg VERSION="$rel_ver" \
-             -t $IMAGE_NAME .
+docker build --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+             --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
+             --build-arg VERSION="$REL_VER" \
+             -t "$IMAGE_NAME" .

--- a/hooks/env
+++ b/hooks/env
@@ -1,5 +1,11 @@
 #!/bin/bash
-set -e
+set -xe
 
 # Get the sem-ver of the latest stable release for tagging
-rel_ver="$(git ls-remote --refs --tags --sort=v:refname git://github.com/eXist-db/exist.git  | awk '{print $2}' | awk -F"/" '{print $3}' | grep -r '^eXist-[0-9]\+\.[0-9]\+\.[0-9]\+$' | tail -n 1 | cut -d \- -f 2)"
+REL_VER=$(curl --silent  'https://api.github.com/repos/eXist-db/exist/releases' | grep 'tag_name' | awk -F":" '{print $2}' | sed s/\",//g | grep -oP '(((\d+)\.?){3})$' | head -1)
+
+echo "latest release is ${REL_VER}"
+
+# The dockerhub build system seem to be ubuntu xenial 
+# use ubuntu:xenial-20180705 container for testing
+# echo "$(uname -a)"

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -e
+set -xe
+
+# see https://docs.docker.com/docker-cloud/builds/advanced/
 
 . ./hooks/env
 
@@ -9,7 +11,7 @@ repoName=${IMAGE_NAME:0:tagStart-1}
 
 
 # Tag and push image for each additional tag
-for tag in {$rel_ver,release}; do
+for tag in {$REL_VER,release}; do
     docker tag $IMAGE_NAME ${repoName}:${tag}
     docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
@grantmacken I tried to clarify the interplay between args and labels inline
we basically need all args, as they are either called by the autobuilds, or must be available for local builds to avoid us(ers) having to restart the JVM inside the container

close #19 

@adamretter 
Tried and tested. All hooks produce properly tagged images. 
let s keep -XE flag for easier debugging the docker hub interface ain't that great
![screen shot 2018-08-14 at 17 05 08](https://user-images.githubusercontent.com/6205362/44102123-40e47920-9fe9-11e8-9d01-7e22994f1a7c.png)

RC still require manual tagging, what we want to do for develop is a separate issue for now. 