### PR TITLE
Enhance 25 dockerfile build args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,44 @@
 sudo: required
-
-language: ruby
-
+dist: trusty
+language: c
 services:
   - docker
 
-before_install:
-  - docker build -t existdb/existdb .
-  - docker run -it -d --name exist -p 8080:8080 existdb/existdb
+jobs:
+   include:
+     - stage: given ver string build image from VERSION build-arg
+       env: 
+        - VERSION=4.3.1
+        - DOCKER_TAG=4.3.1
+       install: skip
+       script:
+       - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
+       - docker-compose up -d
+       - docker ps -a | grep 'exist'
+       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
+       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+       - docker logs exist | grep 'Server has started'
+       - docker-compose down
+     - stage: given commit hash build image from BRANCH build-arg
+       env: DOCKER_TAG=3b195797a
+       install: skip
+       script:
+       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
+       - docker-compose up -d
+       - docker ps -a | grep 'exist'
+       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
+       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+       - docker logs exist | grep 'Server has started'
+       - docker-compose down
+     - stage: given master branch name build image from BRANCH build-arg
+       env: DOCKER_TAG=master
+       install: skip
+       script:
+       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
+       - docker-compose up -d
+       - docker ps -a | grep 'exist'
+       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
+       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+       - docker logs exist | grep 'Server has started'
+       - docker-compose down
 
-before_script:
-  - sleep 35
-script:
-  - docker exec exist java -version
-  - docker logs exist
-  - docker ps -a


### PR DESCRIPTION
The revised Dockerfile  is the result of working on  #25 
The revised travis file is the result of working on #24 
 Travis will now carry out 3 jobs.  See [ last build on travis-ci ](https://travis-ci.com/eXist-db/docker-existdb/builds/82492906)
Each job will 
 1. build an image from distinct build-arg(s)
2.  use docker-compose to bring the freshly minted container up
3. run some simple smoke tests on running container

It should be good to go for merging into develop then master
p.s. using  docker-compose in travis-ci also opens up some option for running more functional tests


