### PR TITLE
Enhance 27 functional tests for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,27 +30,7 @@ jobs:
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
        - echo ' CHECK! curl'
-       - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -w '%{http_code}' $URL -d @tests/fixtures/t1.xml
-       # - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
-       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
-       # - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
-       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null | grep 'dashboard'
-       # - echo ' CHECK! eXist home'
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'system:get-exist-home()' 2>/dev/null
-       # - echo ' CHECK! copying conf.xml to local disk'
-       # - docker cp exist:eXist/config/conf.xml ./conf.xml
-       # - test -e './conf.xml'
-       # - echo ' CHECK! copying local conf.xml into container'
-       # - docker cp  ./conf.xml exist:eXist/config/conf.xml
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file\:list(\"/\")' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-       #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-       #   'file:read(\"config/conf.xml\")' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file:list(\"config/conf.xml\")' 2>/dev/null"
-       # - echo ' CHECK! logging to system out'
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
-       # - docker logs exist | tail
+       - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' $URL -d @./tests/fixtures/t1.xml
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg
@@ -77,4 +57,23 @@ jobs:
      #   - docker-compose down
 
 
-       # - 
+       # - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
+       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       # - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
+       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null | grep 'dashboard'
+       # - echo ' CHECK! eXist home'
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'system:get-exist-home()' 2>/dev/null
+       # - echo ' CHECK! copying conf.xml to local disk'
+       # - docker cp exist:eXist/config/conf.xml ./conf.xml
+       # - test -e './conf.xml'
+       # - echo ' CHECK! copying local conf.xml into container'
+       # - docker cp  ./conf.xml exist:eXist/config/conf.xml
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file\:list(\"/\")' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+       #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+       #   'file:read(\"config/conf.xml\")' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file:list(\"config/conf.xml\")' 2>/dev/null"
+       # - echo ' CHECK! logging to system out'
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
+       # - docker logs exist | tail

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,15 @@ jobs:
           curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no" | \
           grep "$VERSION"
        - |
+          # use REST interface via CURL
           # CHECK! the ability to
           #  - invoke a http client (curl)
-          #  - to query the database by POSTing
-          # when calling repo:list(),
-          # a list of items should be grepped TODO
+          #  - to query the database by POSTing a query
+          #
+          #  the list returned from a repo:list() query,
+          #  should grep 'http://' 
           set -eo pipefail
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep 'http://'
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
@@ -63,7 +65,7 @@ jobs:
           </query>
           EOF
        - |
-          # listing fils in config dir
+          # listing files in config dir
           # CHECK! with the exist containers provided config dir,
           # a user should be able to list configuration files
           # that will enable user to alter eXist start up options.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,20 @@ jobs:
        - docker ps -a | grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - docker logs exist | grep '^.+\K(Server has started.+$)'
+       - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
        - sleep 30
-       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2> /dev/null
-       - ${DEX} 'sm:is-dba(xmldb:get-current-user())'  2> /dev/null | grep 'true'
-       - ${DEX} 'system:get-version()'  2> /dev/null  | grep "$VERSION"
-       - ${DEX} 'system:get-version()'  2> /dev/null  | grep "$VERSION"
+       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
+       - ${DEX} 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       - ${DEX} 'system:get-version()'  2>/dev/null
+       - ${DEX} 'string-join(repo:list(), "&#10;")' 2>/dev/null
        - docker ps | grep -o 'healthy'
-       - docker inspect ex
+       - docker inspect exist
+       - echo ' - copy conf.xml to local disk'
+       - docker cp exist:eXist/config/conf.xml ./conf.xml
+       - echo ' - check file exists'
+       - [ -e conf.xml ]
+       - echo ' - copy conf.xml into container'
+       - docker cp  ./conf.xml exist:eXist/config/conf.xml
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,13 @@ jobs:
           docker ps -a | \
           grep 'exist' | \
           grep -oP 'health.\sstarting'
-       - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
+       - |
+          # WAIT! until eXist can be reached
+          # set -eo pipefail
+          N=0
+          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
+            do sleep $(( N++ ))
+          done
        - |
           # CHECK! eXist can be reached via http
           # response header should grep Jetty
@@ -33,7 +39,7 @@ jobs:
           # CHECK! docker logs should show server has started
           set -eo pipefail
           docker logs exist | \
-          grep -oP '^.+\K(Server has started.+)$'
+          grep -oP '^.+\KServer has started.+'
        - sleep 30
        - |
           # CHECK! healthcheck should register healthy
@@ -45,7 +51,7 @@ jobs:
           #  - invoke client.jar
           #  - change password
           #  - query db with new pass
-          # the is-dba() query call should return true
+          # after changing passwoed the is-dba() query call should return true
           set -eo pipefail
           docker exec exist java -jar start.jar client -q -u admin -P '' \
           -x 'sm:passwd("admin", "nimda")' 2>/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
           # CHECK! with a http client like curl,
           # user should be be able to use the rest interface
           # to POST a query to the database
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep dashboard
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap'no'>
           <text><![CDATA[
           xquery version '3.1';
@@ -48,6 +48,22 @@ jobs:
           ]]></text>
           </query>
           EOF
+       - |
+          set -eo pipefail
+          # CHECK! user should be able to
+          # copy a config file from container to local disk'
+          docker cp exist:eXist/config/conf.xml ./conf.xml \
+          && [[ -e ./conf.xml ]]
+       - |
+          set -eo pipefail
+          # CHECK! user should be able to
+          # copy conf.xml into container TODO TEST
+          docker cp ./conf.xml exist:eXist/config/conf.xml
+       - |
+          set -eo pipefail
+          # CHECK! with changes made to logger
+          # logged data should be able to
+          # be viewed in docker logs TODO
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,16 @@ jobs:
        - test -e './conf.xml'
        - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
-        - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-          'file\:list(\"/\")' 2>/dev/null"
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file\:list(\"/\")' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
        #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
        #   'file:read(\"config/conf.xml\")' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-       #   'file:list(\"config/conf.xml\")' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file:list(\"config/conf.xml\")' 2>/dev/null"
        - echo ' CHECK! logging to system out'
-       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-         'util:log-system-out(\"HELLO WORLD!\")' 2>/dev/null"
+       - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
        - docker logs exist | tail
+       - echo ' CHECK! curl'
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg
@@ -80,11 +78,5 @@ jobs:
      #   - docker logs exist | grep 'Server has started'
      #   - docker-compose down
 
-# - docer inspect exist
-# curl -s \
-#   -H "Content-Type: text/xml" \
-#   -u "${KNOWN_USER}:${KNOWN_PASS}" \
-#   -o ${TEMP_XML} \
-#   -w "%{http_code}" \
-#   -d "${POST}" \
-#   http://${HOST}:8080/exist/rest/db
+
+       # - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -w '%{http_code}' http://127.0.0.1:8080/exist/rest/db -d 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,11 @@ jobs:
        - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
-       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       - "docker exec exist java -jar start.jar client -q -u admin -P nimda
+         -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | grep -o 'admin'"
        - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
        - "docker exec exist java -jar start.jar client -q -u admin -P nimda
-         -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep dashboard"
+         -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep 'dashboard'"
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
        - echo ' CHECK! copying conf.xml to local disk'
@@ -38,7 +39,14 @@ jobs:
        - test -e './conf.xml'
        - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
-       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x  'file:exists("./config/conf.xml"))' 2>/dev/null
+       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+         'file:exists(\"config/conf.xml\"))' 2>/dev/null"
+       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+         'file:read(\"config/conf.xml\")' 2>/dev/null"
+       - echo ' CHECK! logging to system out'
+       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+         'util:log-system-out(\"HELLO WORLD!\") 2>/dev/null"
+       - docker logs exist | tail
        - docker-compose down
 
      # - docker inspect exist

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
        - docker ps -a | grep -oP 'health.\sstarting)'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+       - docker exec exist java -jar start.jar client -q -x 'system:get-version()' | grep "$VERSION"
        - docker logs exist | grep 'Server has started'
        - docker ps | grep 'health'
        - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ jobs:
        - sleep 30
        - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-       - docker logs exist | tail -n 3
+       - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
        - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
-       - "docker exec exist java -jar start.jar client -q -u admin -P nimda
-         -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | grep -o 'admin'"
+       - docker exec exist java -jar start.jar client -q -u admin -P nimda 
+         -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null"
        - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
        - "docker exec exist java -jar start.jar client -q -u admin -P nimda
          -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep 'dashboard'"
@@ -44,7 +44,7 @@ jobs:
        - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
         - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-          'file:list(\"/\")' 2>/dev/null"
+          'file\:list(\"/\")' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
        #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
@@ -57,7 +57,6 @@ jobs:
        - docker logs exist | tail
        - docker-compose down
 
-     # - docker inspect exist
      # - stage: given commit hash build image from BRANCH build-arg
      #   env: DOCKER_TAG=3b195797a
      #   install: skip
@@ -81,3 +80,11 @@ jobs:
      #   - docker logs exist | grep 'Server has started'
      #   - docker-compose down
 
+# - docer inspect exist
+# curl -s \
+#   -H "Content-Type: text/xml" \
+#   -u "${KNOWN_USER}:${KNOWN_PASS}" \
+#   -o ${TEMP_XML} \
+#   -w "%{http_code}" \
+#   -d "${POST}" \
+#   http://${HOST}:8080/exist/rest/db

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,16 @@ jobs:
        - "docker ps | grep -o 'healthy'"
        - |
           set -eo pipefail
-          # CHECK! the ability to 
+          # CHECK! the ability to
           #  - invoke client.jar
           #  - change password
-          # this config change should show up in eXist logs
+          #  - query db with new pass
+          # the is-dba() query call should return true
           docker exec exist java -jar start.jar client -q -u admin -P '' \
-          -x 'sm:passwd("admin", "nimda")' 2>/dev/null && \
-          docker logs exist | tail -n 3 | \
-          grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
+          -x 'sm:passwd("admin", "nimda")' 2>/dev/null \
+          && docker exec exist java -jar start.jar client -q -u admin -P nimda \
+          -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | \
+          grep 'true'
        - |
           set -eo pipefail
           # CHECK! the ability to
@@ -103,16 +105,15 @@ jobs:
           <text><![CDATA[
           xquery version '3.1';
           (
-          'TODO' ||  '&#10;',
-          util:log-system-out('system-out HELLO WORLD!'),
-          util:log-system-err('system-err HELLO WORLD!'),
-          util:log('INFO', 'log INFO '),
-          util:log('WARN', 'log WARN' )
+          util:log-system-out('HELLO SYSTEM-OUT!'),
+          util:log-system-err('HELLO SYSTEM-ERR!'),
+          util:log('INFO', 'HELLO logged INFO!'),
+          util:log('WARN', 'HELLO logged WARN' )
           )
           ]]></text>
           </query>
           EOF
-          } && docker logs exist
+          } && docker logs exist | grep HELLO
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2> /dev/null
        - $DEX 'sm:is-dba(xmldb:get-current-user())'  2> /dev/null | grep 'true'
        - $DEX 'system:get-version()'  2> /dev/null  | grep "$VERSION"
-       - docker ps | grep 'health'
+       - docker ps | grep -o 'healthy'
        - docker inspect ex
        - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,27 @@ jobs:
        - sleep 30
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
-       - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
+       - echo ' CHECK! by invoking client.jar, user should be able to change password can change password'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
-       - echo ' CHECK! curl'
+       - echo ' CHECK! with an http client like curl, user should be be able to use the rest interface' 
        - echo "${URL}"
        - ls -al ./tests/fixtures/t1.xml
        - |
-         # try to build surl string 
+         #  get the root collection
          curl -s "$URL"
+       - |
+          # post a query
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          <query xmlns='http://exist.sourceforge.net/NS/exist'
+            start='1'
+            max='99'>
+          <text><![CDATA[
+          xquery version '3.1'; 
+          string-join(repo:list(), '&#10;')
+          ]]></text>
+          </query>
+          EOF
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,27 @@ jobs:
        script:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
+       - echo ' CHECK! ps cmd should be able to grep exist'
        - docker ps -a | grep 'exist'
+       - echo ' CHECK! ps cmd should show health status'
        - docker ps -a | grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - echo ' - check\: eXist logs should show server hasd started'
+       - echo ' CHECK! eXist logs should show server has started'
        - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
        - sleep 30
-       - echo ' - check\: user can change password'
+       - echo ' CHECK! client should show admin user'
+       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'xmldb:get-current-user()' 2>/dev/null
+       - echo ' CHECK! user can change password'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
-       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'system:get-version()'  2>/dev/null
-       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null
-       - echo ' - check\: healthcheck should register healthy'
+       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null
+       - echo ' CHECK! healthcheck should register healthy'
        - docker ps | grep -o 'healthy'
-       - echo ' - check\: copying conf.xml to local disk'
+       - echo ' CHECK! copying conf.xml to local disk'
        - docker cp exist:eXist/config/conf.xml ./conf.xml
        - test -e './conf.xml'
-       - echo ' - copy conf.xml into container'
+       - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
        - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,24 +91,7 @@ jobs:
           ]]></text>
           </query>
           EOF
-       - |
-          # listing files in config dir
-          # CHECK! with the exist containers provided config dir,
-          # a user should be able to list configuration files
-          # that will enable user to alter eXist start up options.
-          set -eo pipefail
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
-          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
-          <text><![CDATA[
-          xquery version '3.1';
-          let $eXistHome := system:get-exist-home()
-          let $configDir := concat($eXistHome || '/config')
-          let $fileList := file:list( configDir )
-          return
-           $fileList
-          ]]></text>
-          </query>
-          EOF
+
        - |
           # manage config files
           # CHECK! the ability to
@@ -131,7 +114,10 @@ jobs:
           docker cp ./conf.xml exist:eXist/config/conf.xml
           docker-compose down &>/dev/null
           docker-compose up -d &>/dev/null
-          N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
+          N=0
+          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
+            do sleep $(( N++ ))
+          done
           docker logs exist | grep '60,000 ms during shutdown'
        - |
           # log to docker logs
@@ -179,3 +165,21 @@ jobs:
      #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
      #   - docker logs exist | grep 'Server has started'
      #   - docker-compose down
+
+# a # listing files in config dir
+#  # CHECK! with the exist containers provided config dir,
+#  # a user should be able to list configuration files
+#  # that will enable user to alter eXist start up options.
+#  set -eo pipefail
+#  cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+#  <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+#  <text><![CDATA[
+#  xquery version '3.1';
+#  let $eXistHome := system:get-exist-home()
+#  let $configDir := concat($eXistHome, '/config')
+#  let $fileList := file:list( configDir )
+#  return
+#   $fileList
+#  ]]></text>
+#  </query>
+#  EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,8 @@ jobs:
           # CHECK! the ability to
           # - copy a config file from container to local disk
           # after copying conf.xml the file should exist locally
-          # TEST make fail
           docker cp exist:eXist/config/conf.xml ./conf.xml \
-          && [[ -e ./con.xml ]] && ls -l ./conf.xml
+          && [[ -e ./conf.xml ]] && ls -l ./conf.xml
        - |
           set -eo pipefail
           # CHECK! the abilty to

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,16 @@ jobs:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
        - docker ps -a | grep 'exist'
-       - docker ps -a | grep -oP 'health.\sstarting)'
+       - docker ps -a | grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - docker exec exist java -jar start.jar client -q -x 'system:get-version()' | grep "$VERSION"
        - docker logs exist | grep 'Server has started'
+       - sleep 30
+       - docker exec exist java -jar start.jar client -q -x 'system:get-version()' | grep "$VERSION"
        - docker ps | grep 'health'
+       - docker inspect ex
        - docker-compose down
+
      # - stage: given commit hash build image from BRANCH build-arg
      #   env: DOCKER_TAG=3b195797a
      #   install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
        - docker logs exist | grep 'Server has started'
        - sleep 30
        - docker exec exist java -jar start.jar client -q -x 'system:get-version()' | grep "$VERSION"
+       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")'
        - docker ps | grep 'health'
        - docker inspect ex
        - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,31 @@ jobs:
        script:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
-       - echo ' CHECK! ps cmd should be able to grep exist'
-       - docker ps -a | grep 'exist'
-       - echo ' CHECK! ps cmd should show health status'
-       - docker ps -a | grep -oP 'health.\sstarting'
+          # CHECK! eXist is starting with health status
+          #  ps cmd should show health status as starting
+          set -eo pipefail
+          docker ps -a | \
+          grep 'exist' | \
+          grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
-       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - echo ' CHECK! eXist logs should show server has started'
-       - docker logs exist | grep -oP '^.+\K(Server has started.+)$'
-       - sleep 30
-       - echo ' CHECK! healthcheck should register healthy'
-       - "docker ps | grep -o 'healthy'"
        - |
+          # CHECK! eXist can be reached via http
+          # response header should grep Jetty
+          set -eo pipefail
+          curl -Is http://127.0.0.1:8080/ | \
+          grep 'Jetty'
+       - |
+          # CHECK! docker logs should show server has started
+          set -eo pipefail
+          docker logs exist | \
+          grep -oP '^.+\K(Server has started.+)$'
+       - sleep 30
+       - |
+          # CHECK! healthcheck should register healthy
+          docker ps | \
+          grep -o 'healthy'
+       - |
+          # changing password with client.jar
           # CHECK! the ability to
           #  - invoke client.jar
           #  - change password
@@ -39,6 +52,8 @@ jobs:
           -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | \
           grep 'true'
        - |
+          # obtain running container eXist 'version'
+          # # http GET request to rest endpoint url via CURL
           # CHECK! the ability to
           #  - invoke a http client (curl)
           #  - use GET to query the database
@@ -48,7 +63,7 @@ jobs:
           curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no" | \
           grep "$VERSION"
        - |
-          # use REST interface via CURL
+          # posting requests to rest endpoint url via CURL
           # CHECK! the ability to
           #  - invoke a http client (curl)
           #  - to query the database by POSTing a query
@@ -80,7 +95,7 @@ jobs:
           </query>
           EOF
        - |
-          # copy config file to local disk
+          # manage config files
           # CHECK! the ability to
           # - copy a config file from container to local disk
           # after copying conf.xml the file should exist locally
@@ -88,7 +103,7 @@ jobs:
           docker cp exist:eXist/config/conf.xml ./conf.xml \
           && [[ -e ./conf.xml ]] && ls -l ./conf.xml
        - |
-          # changed configuration item
+          # persist changed configuration items
           # CHECK! the abilty to
           #  - alter a config item in a config file on local disk,
           #  - copy the altered config file into containers config dir.
@@ -105,7 +120,7 @@ jobs:
           && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
           && docker logs exist | grep '60,000 ms during shutdown'
        - |
-          # logger changes
+          # log to docker logs
           # CHECK! the abilty to
           # - call log functions
           # - view results in docker logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,9 @@ jobs:
           # the is-dba() query call should return true
           set -eo pipefail
           docker exec exist java -jar start.jar client -q -u admin -P '' \
-          -x 'sm:passwd("admin", "nimda")' 2>/dev/null \
-          && docker exec exist java -jar start.jar client -q -u admin -P nimda \
-          -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | \
-          grep 'true'
+          -x 'sm:passwd("admin", "nimda")' 2>/dev/null
+          docker exec exist java -jar start.jar client -q -u admin -P nimda \
+          -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
        - |
           # obtain running container eXist 'version'
           # # http GET request to rest endpoint url via CURL
@@ -91,7 +90,9 @@ jobs:
           <text><![CDATA[
           xquery version '3.1';
           let $fileListNames := file:list( system:get-exist-home() || '/config' )//@name/string()
+          return (
           string-join($fileListNames ,'&#10;' )
+          )
           ]]></text>
           </query>
           EOF
@@ -113,13 +114,12 @@ jobs:
           #
           # The startup log should show altered shutdown time
           set -eo pipefail
-          sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml \
-          && grep 'wait-before-shutdown=' conf.xml \
-          && docker cp ./conf.xml exist:eXist/config/conf.xml \
-          && docker-compose down \
-          && docker-compose up -d \
-          && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
-          && docker logs exist | grep '60,000 ms during shutdown'
+          sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml
+          docker cp ./conf.xml exist:eXist/config/conf.xml
+          docker-compose down &>/dev/null
+          docker-compose up -d &>/dev/null
+          N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
+          docker logs exist | grep '60,000 ms during shutdown'
        - |
           # log to docker logs
           # CHECK! the abilty to
@@ -141,7 +141,7 @@ jobs:
           ]]></text>
           </query>
           EOF
-          } && docker logs exist | grep HELLO
+          } && docker logs exist 2>/dev/null | grep HELLO
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
           </query>
           EOF
        - |
-          set -eo pipefail
+          # copy config file to local disk
           # CHECK! the ability to
           # - copy a config file from container to local disk
           # after copying conf.xml the file should exist locally
@@ -89,21 +89,22 @@ jobs:
        - |
           # changed configuration item
           # CHECK! the abilty to
-          #  - alter a config item in a config file,
+          #  - alter a config item in a config file on local disk,
           #  - copy the altered config file into containers config dir.
-          #  - stopping and starting the container.
-          # The check should show the changed item is effective after start up
-          # TODO
+          #  - stop and start the container
+          #  - view changed item taking effect in startup logs
+          #
+          # The startup log should ... TODO
           set -eo pipefail
           sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml \
           && grep 'wait-before-shutdown=' conf.xml \
           && docker cp ./conf.xml exist:eXist/config/conf.xml \
           && docker-compose down \
           && docker-compose up -d \
-          && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
+          && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
           && docker logs exist | grep 'database instance' | grep  'will wait'
        - |
-          # Changes made to logger
+          # logger changes
           # CHECK! the abilty to
           # - call log functions
           # - view results in docker logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,35 @@ jobs:
        - |
           set -eo pipefail
           # CHECK! with a http client like curl,
-          # user should be be able to use the rest interface
+          # a user should be be able to use the rest interface
+          # to query to the database
+          curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no"
+       - |
+          set -eo pipefail
+          # CHECK! with a http client like curl,
+          # a user should be be able to use the rest interface
           # to POST a query to the database
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
           string-join(repo:list(), '&#10;')
+          ]]></text>
+          </query>
+          EOF
+       - |
+          set -eo pipefail
+          # CHECK! with the exist containers provided config dir,
+          # a user should be able to list configuration files
+          # that will enable user to alter eXist start up options.
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+          <text><![CDATA[
+          xquery version '3.1';
+          string-join(
+            file:list( system:get-exist-home() || '/config' )/@name/string(),
+            '&#10;'
+            )
           ]]></text>
           </query>
           EOF
@@ -70,10 +92,9 @@ jobs:
           xquery version '3.1';
           (
           'TODO',
-          sm:is-dba(xmldb:get-current-user()),
+          sm:is-dba(xmldb:get-current-user()) ,
           util:log-system-out('HELLO WORLD!'),
           system:get-exist-home(),
-          file:list(system:get-exist-home())
           )
           ]]></text>
           </query>

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ jobs:
        - docker logs exist | grep '^.+\K(Server has started.+$)'
        - sleep 30
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2> /dev/null
-       - $DEX 'sm:is-dba(xmldb:get-current-user())'  2> /dev/null | grep 'true'
-       - $DEX 'system:get-version()'  2> /dev/null  | grep "$VERSION"
+       - ${DEX} 'sm:is-dba(xmldb:get-current-user())'  2> /dev/null | grep 'true'
+       - ${DEX} 'system:get-version()'  2> /dev/null  | grep "$VERSION"
+       - ${DEX} 'system:get-version()'  2> /dev/null  | grep "$VERSION"
        - docker ps | grep -o 'healthy'
        - docker inspect ex
        - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ jobs:
           docker cp exist:eXist/config/conf.xml ./conf.xml \
           && [[ -e ./conf.xml ]] && ls -l ./conf.xml
        - |
+          # changed configuration item
           # CHECK! the abilty to
           #  - alter a config item in a config file,
           #  - copy the altered config file into containers config dir.
@@ -94,14 +95,17 @@ jobs:
           # The check should show the changed item is effective after start up
           # TODO
           set -eo pipefail
-          docker cp ./conf.xml exist:eXist/config/conf.xml
+          sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml \
+          && ls . \
+          && grep 'wait-before-shutdown' \
+          && docker cp ./conf.xml exist:eXist/config/conf.xml
        - |
           # Changes made to logger
           # CHECK! the abilty to
           # - call log functions
           # - view results in docker logs
-          # 
-          # eXit log queries should turn up in docker logs
+          #
+          # eXist log queries should turn up in docker logs
           {
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
           # user should be be able to use the rest interface
           # to POST a query to the database
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
-          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap'no'>
+          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
           string-join(repo:list(), '&#10;')
@@ -64,6 +64,20 @@ jobs:
           # CHECK! with changes made to logger
           # logged data should be able to
           # be viewed in docker logs TODO
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+          <text><![CDATA[
+          xquery version '3.1';
+          (
+          'TODO',
+          sm:is-dba(xmldb:get-current-user()),
+          util:log-system-out('HELLO WORLD!'),
+          system:get-exist-home(),
+          file:list(system:get-exist-home())
+          )
+          ]]></text>
+          </query>
+          EOF
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg
@@ -88,27 +102,3 @@ jobs:
      #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
      #   - docker logs exist | grep 'Server has started'
      #   - docker-compose down
-
-
-       # - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
-       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
-       # - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
-       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null | grep 'dashboard'
-       # - echo ' CHECK! eXist home'
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'system:get-exist-home()' 2>/dev/null
-       # - echo ' CHECK! copying conf.xml to local disk'
-       # - docker cp exist:eXist/config/conf.xml ./conf.xml
-       # - test -e './conf.xml'
-       # - echo ' CHECK! copying local conf.xml into container'
-       # - docker cp  ./conf.xml exist:eXist/config/conf.xml
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file\:list(\"/\")' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-       #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-       #   'file:read(\"config/conf.xml\")' 2>/dev/null"
-       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file:list(\"config/conf.xml\")' 2>/dev/null"
-       # - echo ' CHECK! logging to system out'
-       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
-       # - docker logs exist | tail
-       #
-       # - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -d @./tests/fixtures/t1.xml $URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ jobs:
           # CHECK! with changes made to logger
           # logged data should be able to
           # be viewed in docker logs TODO
+          {
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
@@ -112,6 +113,7 @@ jobs:
           ]]></text>
           </query>
           EOF
+          } && docker logs exist
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,17 @@ jobs:
           #  - invoke client.jar
           #  - change password
           #  - query db with new pass
-          # after changing passwoed the is-dba() query call should return true
+          # after changing password the is-dba() query call should return true
           set -eo pipefail
           docker exec exist java -jar start.jar client -q -u admin -P '' \
           -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-          docker exec exist java -jar start.jar client -q -u admin -P nimda \
-          -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+          <text><![CDATA[
+          xquery version '3.1';
+          sm:is-dba(xmldb:get-current-user())
+          ]]></text>
+          </query>
        - |
           # obtain running container eXist 'version'
           # # http GET request to rest endpoint url via CURL

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,33 +27,33 @@ jobs:
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
        - |
-          set -eo pipefail
           # CHECK! the ability to
           #  - invoke client.jar
           #  - change password
           #  - query db with new pass
           # the is-dba() query call should return true
+          set -eo pipefail
           docker exec exist java -jar start.jar client -q -u admin -P '' \
           -x 'sm:passwd("admin", "nimda")' 2>/dev/null \
           && docker exec exist java -jar start.jar client -q -u admin -P nimda \
           -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | \
           grep 'true'
        - |
-          set -eo pipefail
           # CHECK! the ability to
           #  - invoke a http client (curl)
           #  - use GET to query the database
-          #  when calling get-version(),
-          #  the correct version should be grepped
+          #  the get-version() query,
+          #  should match the version of the freshly minted built image
+          set -eo pipefail
           curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no" | \
           grep "$VERSION"
        - |
-          set -eo pipefail
           # CHECK! the ability to
           #  - invoke a http client (curl)
           #  - to query the database by POSTing
           # when calling repo:list(),
           # a list of items should be grepped TODO
+          set -eo pipefail
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
@@ -63,10 +63,10 @@ jobs:
           </query>
           EOF
        - |
-          set -eo pipefail
           # CHECK! with the exist containers provided config dir,
           # a user should be able to list configuration files
           # that will enable user to alter eXist start up options.
+          set -eo pipefail
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
@@ -83,22 +83,25 @@ jobs:
           # CHECK! the ability to
           # - copy a config file from container to local disk
           # after copying conf.xml the file should exist locally
+          set -eo pipefail
           docker cp exist:eXist/config/conf.xml ./conf.xml \
           && [[ -e ./conf.xml ]] && ls -l ./conf.xml
        - |
-          set -eo pipefail
           # CHECK! the abilty to
           #  - alter a config item in a config file,
           #  - copy the altered config file into containers config dir.
           #  - stopping and starting the container.
           # The check should show the changed item is effective after start up
           # TODO
+          set -eo pipefail
           docker cp ./conf.xml exist:eXist/config/conf.xml
        - |
-          set -eo pipefail
-          # CHECK! with changes made to logger
-          # logged data should be able to
-          # be viewed in docker logs TODO
+          # Changes made to logger
+          # CHECK! the abilty to
+          # - call log functions
+          # - view results in docker logs
+          # 
+          # eXit log queries should turn up in docker logs
           {
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,14 @@ jobs:
           set -eo pipefail
           docker exec exist java -jar start.jar client -q -u admin -P '' \
           -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep 'true'
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
           sm:is-dba(xmldb:get-current-user())
           ]]></text>
           </query>
+          EOF
        - |
           # obtain running container eXist 'version'
           # # http GET request to rest endpoint url via CURL
@@ -100,10 +101,11 @@ jobs:
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
-          let $fileListNames := file:list( system:get-exist-home() || '/config' )//@name/string()
-          return (
-          string-join($fileListNames ,'&#10;' )
-          )
+          let $eXistHome := system:get-exist-home()
+          let $configDir := concat($eXistHome || '/config')
+          let $fileList := file:list( configDir )
+          return
+           $fileList
           ]]></text>
           </query>
           EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ jobs:
         - URL=http://127.0.0.1:8080/exist/rest/db
        install: skip
        script:
-       - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
-       - docker-compose up -d
+       - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" . &>/dev/null
+       - docker-compose up -d  &>/dev/null
+       - |
           # CHECK! eXist is starting with health status
           #  ps cmd should show health status as starting
           set -eo pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
        env: 
         - VERSION=4.3.1
         - DOCKER_TAG=4.3.1
+        - DEX='docker exec java -jar start.jar client -q -u admin -P nimda -x'
        install: skip
        script:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
@@ -18,10 +19,11 @@ jobs:
        - docker ps -a | grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - docker logs exist | grep 'Server has started'
+       - docker logs exist | grep '^.+\K(Server has started.+$)'
        - sleep 30
-       - docker exec exist java -jar start.jar client -q -x 'system:get-version()' | grep "$VERSION"
-       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")'
+       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2> /dev/null
+       - $DEX 'sm:is-dba(xmldb:get-current-user())'  2> /dev/null | grep 'true'
+       - $DEX 'system:get-version()'  2> /dev/null  | grep "$VERSION"
        - docker ps | grep 'health'
        - docker inspect ex
        - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,14 @@ jobs:
        - sleep 30
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
-       - echo ' CHECK! by invoking client.jar, user should be able to change password can change password'
-       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-       - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
+       - |
+          # CHECK! by invoking client.jar,
+          # user should be able to change password and
+          # this config change will show up in eXist logs
+          docker exec exist java -jar start.jar client -q -u admin -P '' \
+          -x 'sm:passwd("admin", "nimda")' 2>/dev/null && \
+          docker logs exist | tail -n 3 | \
+          grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
        - |
           set -eo pipefail
           # CHECK! with a http client like curl,

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ jobs:
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
        - echo ' CHECK! curl'
-       - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' $URL -d @./tests/fixtures/t1.xml
+       - echo "${URL}"
+       - ls -al ./tests/fixtures/t1.xml
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg
@@ -77,3 +78,5 @@ jobs:
        # - echo ' CHECK! logging to system out'
        # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
        # - docker logs exist | tail
+       #
+       # - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -d @./tests/fixtures/t1.xml $URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
        env: 
         - VERSION=4.3.1
         - DOCKER_TAG=4.3.1
-        - DEX='docker exec java -jar start.jar client -q -u admin -P nimda -x'
+        - URL=http://127.0.0.1:8080/exist/rest/db
        install: skip
        script:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
@@ -24,35 +24,33 @@ jobs:
        - echo ' CHECK! eXist logs should show server has started'
        - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
        - sleep 30
+       - echo ' CHECK! healthcheck should register healthy'
+       - "docker ps | grep -o 'healthy'"
        - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
-       - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
-       - docker exec exist java -jar start.jar client -q -u admin -P nimda 
-         -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null"
-       - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
-       - "docker exec exist java -jar start.jar client -q -u admin -P nimda
-         -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep 'dashboard'"
-       - echo ' CHECK! healthcheck should register healthy'
-       - "docker ps | grep -o 'healthy'"
-       - echo ' CHECK! eXist home'
-       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-         'system:get-exist-home()' 2>/dev/null"
-       - echo ' CHECK! copying conf.xml to local disk'
-       - docker cp exist:eXist/config/conf.xml ./conf.xml
-       - test -e './conf.xml'
-       - echo ' CHECK! copying local conf.xml into container'
-       - docker cp  ./conf.xml exist:eXist/config/conf.xml
+       - echo ' CHECK! curl'
+       - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -w '%{http_code}' $URL -d @tests/fixtures/t1.xml
+       # - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
+       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       # - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
+       # - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null | grep 'dashboard'
+       # - echo ' CHECK! eXist home'
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'system:get-exist-home()' 2>/dev/null
+       # - echo ' CHECK! copying conf.xml to local disk'
+       # - docker cp exist:eXist/config/conf.xml ./conf.xml
+       # - test -e './conf.xml'
+       # - echo ' CHECK! copying local conf.xml into container'
+       # - docker cp  ./conf.xml exist:eXist/config/conf.xml
        # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file\:list(\"/\")' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
        #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
        #   'file:read(\"config/conf.xml\")' 2>/dev/null"
        # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'file:list(\"config/conf.xml\")' 2>/dev/null"
-       - echo ' CHECK! logging to system out'
-       - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
-       - docker logs exist | tail
-       - echo ' CHECK! curl'
+       # - echo ' CHECK! logging to system out'
+       # - docker exec exist java -jar start.jar client -q -u admin -p nimda -x 'util:log-system-out("HELLO WORLD!")' 2>/dev/null
+       # - docker logs exist | tail
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg
@@ -79,4 +77,4 @@ jobs:
      #   - docker-compose down
 
 
-       # - curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' -w '%{http_code}' http://127.0.0.1:8080/exist/rest/db -d 
+       # - 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,24 @@ jobs:
        - docker ps -a | grep -oP 'health.\sstarting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+       - echo ' - check\: eXist logs should show server hasd started'
        - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
        - sleep 30
+       - echo ' - check\: user can change password'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-       - ${DEX} 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
-       - ${DEX} 'system:get-version()'  2>/dev/null
-       - ${DEX} 'string-join(repo:list(), "&#10;")' 2>/dev/null
+       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
+       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'system:get-version()'  2>/dev/null
+       - docker exec java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null
+       - echo ' - check\: healthcheck should register healthy'
        - docker ps | grep -o 'healthy'
-       - docker inspect exist
-       - echo ' - copy conf.xml to local disk'
+       - echo ' - check\: copying conf.xml to local disk'
        - docker cp exist:eXist/config/conf.xml ./conf.xml
-       - echo ' - check file exists'
-       - [ -e conf.xml ]
+       - test -e './conf.xml'
        - echo ' - copy conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
        - docker-compose down
 
+     # - docker inspect exist
      # - stage: given commit hash build image from BRANCH build-arg
      #   env: DOCKER_TAG=3b195797a
      #   install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,24 +28,30 @@ jobs:
        - "docker ps | grep -o 'healthy'"
        - |
           set -eo pipefail
-          # CHECK! by invoking client.jar,
-          # user should be able to change password and
-          # this config change will show up in eXist logs
+          # CHECK! the ability to 
+          #  - invoke client.jar
+          #  - change password
+          # this config change should show up in eXist logs
           docker exec exist java -jar start.jar client -q -u admin -P '' \
           -x 'sm:passwd("admin", "nimda")' 2>/dev/null && \
           docker logs exist | tail -n 3 | \
           grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
        - |
           set -eo pipefail
-          # CHECK! with a http client like curl,
-          # a user should be be able to use the rest interface
-          # to query to the database
-          curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no"
+          # CHECK! the ability to
+          #  - invoke a http client (curl)
+          #  - use GET to query the database
+          #  when calling get-version(),
+          #  the correct version should be grepped
+          curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no" | \
+          grep "$VERSION"
        - |
           set -eo pipefail
-          # CHECK! with a http client like curl,
-          # a user should be be able to use the rest interface
-          # to POST a query to the database
+          # CHECK! the ability to
+          #  - invoke a http client (curl)
+          #  - to query the database by POSTing
+          # when calling repo:list(),
+          # a list of items should be grepped TODO
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
@@ -72,14 +78,20 @@ jobs:
           EOF
        - |
           set -eo pipefail
-          # CHECK! user should be able to
-          # copy a config file from container to local disk'
+          # CHECK! the ability to
+          # - copy a config file from container to local disk
+          # after copying conf.xml the file should exist locally
+          # TEST make fail
           docker cp exist:eXist/config/conf.xml ./conf.xml \
-          && [[ -e ./conf.xml ]]
+          && [[ -e ./con.xml ]] && ls -l ./conf.xml
        - |
           set -eo pipefail
-          # CHECK! user should be able to
-          # copy conf.xml into container TODO TEST
+          # CHECK! the abilty to
+          #  - alter a config item in a config file,
+          #  - copy the altered config file into containers config dir.
+          #  - stopping and starting the container.
+          # The check should show the changed item is effective after start up
+          # TODO
           docker cp ./conf.xml exist:eXist/config/conf.xml
        - |
           set -eo pipefail
@@ -91,10 +103,11 @@ jobs:
           <text><![CDATA[
           xquery version '3.1';
           (
-          'TODO',
-          sm:is-dba(xmldb:get-current-user()) ,
-          util:log-system-out('HELLO WORLD!'),
-          system:get-exist-home(),
+          'TODO' ||  '&#10;',
+          util:log-system-out('system-out HELLO WORLD!'),
+          util:log-system-err('system-err HELLO WORLD!'),
+          util:log('INFO', 'log INFO '),
+          util:log('WARN', 'log WARN' )
           )
           ]]></text>
           </query>

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,19 @@ jobs:
        - echo ' CHECK! by invoking client.jar, user should be able to change password can change password'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker logs exist | tail -n 3 | grep -oP '^.+\K(INFO(.+)Storing configuration(.+$))'
-       - echo ' CHECK! with an http client like curl, user should be be able to use the rest interface' 
-       - echo "${URL}"
-       - ls -al ./tests/fixtures/t1.xml
        - |
-         #  get the root collection
-         curl -s "$URL"
-       - |
-          # post a query
+          set -eo pipefail
+          # CHECK! with a http client like curl,
+          # user should be be able to use the rest interface
+          # to POST a query to the database
           cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
-          <query xmlns='http://exist.sourceforge.net/NS/exist'
-            start='1'
-            max='99'>
+          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap'no'>
           <text><![CDATA[
-          xquery version '3.1'; 
+          xquery version '3.1';
           string-join(repo:list(), '&#10;')
           ]]></text>
           </query>
-          EOF
+          EOF | grep dashboard
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,21 @@ jobs:
        - echo ' CHECK! eXist logs should show server has started'
        - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
        - sleep 30
-       - echo ' CHECK! client should show admin user'
-       - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'xmldb:get-current-user()' 2>/dev/null
        - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
+       - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
        - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
-       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null
+       - echo ' CHECK! after invoking eXist module functions, user we should be able to grep dashboard'
+       - "docker exec exist java -jar start.jar client -q -u admin -P nimda
+         -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep dashboard"
        - echo ' CHECK! healthcheck should register healthy'
-       - docker ps | grep -o 'healthy'
+       - "docker ps | grep -o 'healthy'"
        - echo ' CHECK! copying conf.xml to local disk'
        - docker cp exist:eXist/config/conf.xml ./conf.xml
        - test -e './conf.xml'
        - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
+       - docker exec exist java -jar start.jar client -q -u admin -P nimda -x  'file:exists("./config/conf.xml"))' 2>/dev/null
        - docker-compose down
 
      # - docker inspect exist

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
        - sleep 30
        - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
+       - docker logs exist | tail -n 3
        - echo ' CHECK! by invoking client.jar, user should be able to query eXist database'
        - "docker exec exist java -jar start.jar client -q -u admin -P nimda
          -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null | grep -o 'admin'"
@@ -34,18 +35,25 @@ jobs:
          -x 'string-join(repo:list(), \"&#10;\")' 2>/dev/null | grep 'dashboard'"
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
+       - echo ' CHECK! eXist home'
+       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+         'system:get-exist-home()' 2>/dev/null"
        - echo ' CHECK! copying conf.xml to local disk'
        - docker cp exist:eXist/config/conf.xml ./conf.xml
        - test -e './conf.xml'
        - echo ' CHECK! copying local conf.xml into container'
        - docker cp  ./conf.xml exist:eXist/config/conf.xml
-       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-         'file:exists(\"config/conf.xml\"))' 2>/dev/null"
-       - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-         'file:read(\"config/conf.xml\")' 2>/dev/null"
+        - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+          'file:list(\"/\")' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+       #   'file:exists(\"config/conf.xml\"))' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+       #   'file:read(\"config/conf.xml\")' 2>/dev/null"
+       # - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
+       #   'file:list(\"config/conf.xml\")' 2>/dev/null"
        - echo ' CHECK! logging to system out'
        - "docker exec exist java -jar start.jar client -q -u admin -p nimda -x
-         'util:log-system-out(\"HELLO WORLD!\") 2>/dev/null"
+         'util:log-system-out(\"HELLO WORLD!\")' 2>/dev/null"
        - docker logs exist | tail
        - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
        - sleep 30
        - echo ' CHECK! client should show admin user'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'xmldb:get-current-user()' 2>/dev/null
-       - echo ' CHECK! user can change password'
+       - echo ' CHECK! user should be able to change password can change password, by invoking client.jar'
        - docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")' 2>/dev/null
        - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'sm:is-dba(xmldb:get-current-user())' 2>/dev/null
        - docker exec exist java -jar start.jar client -q -u admin -P nimda -x 'string-join(repo:list(), "&#10;")' 2>/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ jobs:
           </query>
           EOF
        - |
+          # listing fils in config dir
           # CHECK! with the exist containers provided config dir,
           # a user should be able to list configuration files
           # that will enable user to alter eXist start up options.
@@ -71,10 +72,8 @@ jobs:
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
           <text><![CDATA[
           xquery version '3.1';
-          string-join(
-            file:list( system:get-exist-home() || '/config' )/@name/string(),
-            '&#10;'
-            )
+          let $fileListNames := file:list( system:get-exist-home() || '/config' )//@name/string()
+          string-join($fileListNames ,'&#10;' )
           ]]></text>
           </query>
           EOF
@@ -94,7 +93,7 @@ jobs:
           #  - stop and start the container
           #  - view changed item taking effect in startup logs
           #
-          # The startup log should ... TODO
+          # The startup log should show altered shutdown time
           set -eo pipefail
           sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml \
           && grep 'wait-before-shutdown=' conf.xml \
@@ -102,7 +101,7 @@ jobs:
           && docker-compose down \
           && docker-compose up -d \
           && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done \
-          && docker logs exist | grep 'database instance' | grep  'will wait'
+          && docker logs exist | grep '60,000 ms during shutdown'
        - |
           # logger changes
           # CHECK! the abilty to

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
        - |
+          set -eo pipefail
           # CHECK! by invoking client.jar,
           # user should be able to change password and
           # this config change will show up in eXist logs
@@ -39,14 +40,14 @@ jobs:
           # CHECK! with a http client like curl,
           # user should be be able to use the rest interface
           # to POST a query to the database
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
+          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep dashboard
           <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap'no'>
           <text><![CDATA[
           xquery version '3.1';
           string-join(repo:list(), '&#10;')
           ]]></text>
           </query>
-          EOF | grep dashboard
+          EOF
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ jobs:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
        - docker ps -a | grep 'exist'
+       - docker ps -a | grep 'health: starting'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
-       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
        - docker logs exist | grep 'Server has started'
+       - docker ps -a | grep 'healthy'
        - docker-compose down
      # - stage: given commit hash build image from BRANCH build-arg
      #   env: DOCKER_TAG=3b195797a

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
        - echo ' CHECK! eXist logs should show server has started'
-       - docker logs exist | grep -oP '^.+\K(Server has started.+$)'
+       - docker logs exist | grep -oP '^.+\K(Server has started.+)$'
        - sleep 30
        - echo ' CHECK! healthcheck should register healthy'
        - "docker ps | grep -o 'healthy'"
@@ -32,6 +32,9 @@ jobs:
        - echo ' CHECK! curl'
        - echo "${URL}"
        - ls -al ./tests/fixtures/t1.xml
+       - |
+         # try to build surl string 
+         curl -s "$URL"
        - docker-compose down
 
      # - stage: given commit hash build image from BRANCH build-arg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,30 +15,31 @@ jobs:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
        - docker ps -a | grep 'exist'
+       - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
        - docker logs exist | grep 'Server has started'
        - docker-compose down
-     - stage: given commit hash build image from BRANCH build-arg
-       env: DOCKER_TAG=3b195797a
-       install: skip
-       script:
-       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
-       - docker-compose up -d
-       - docker ps -a | grep 'exist'
-       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
-       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - docker logs exist | grep 'Server has started'
-       - docker-compose down
-     - stage: given master branch name build image from BRANCH build-arg
-       env: DOCKER_TAG=master
-       install: skip
-       script:
-       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
-       - docker-compose up -d
-       - docker ps -a | grep 'exist'
-       - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
-       - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-       - docker logs exist | grep 'Server has started'
-       - docker-compose down
+     # - stage: given commit hash build image from BRANCH build-arg
+     #   env: DOCKER_TAG=3b195797a
+     #   install: skip
+     #   script:
+     #   - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
+     #   - docker-compose up -d
+     #   - docker ps -a | grep 'exist'
+     #   - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
+     #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+     #   - docker logs exist | grep 'Server has started'
+     #   - docker-compose down
+     # - stage: given master branch name build image from BRANCH build-arg
+     #   env: DOCKER_TAG=master
+     #   install: skip
+     #   script:
+     #   - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
+     #   - docker-compose up -d
+     #   - docker ps -a | grep 'exist'
+     #   - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
+     #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
+     #   - docker logs exist | grep 'Server has started'
+     #   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ jobs:
        - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
        - docker-compose up -d
        - docker ps -a | grep 'exist'
-       - docker ps -a | grep 'health: starting'
+       - docker ps -a | grep -oP 'health.\sstarting)'
        - N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
        - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
        - docker logs exist | grep 'Server has started'
-       - docker ps -a | grep 'healthy'
+       - docker ps | grep 'health'
        - docker-compose down
      # - stage: given commit hash build image from BRANCH build-arg
      #   env: DOCKER_TAG=3b195797a

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,9 +96,12 @@ jobs:
           # TODO
           set -eo pipefail
           sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml \
-          && ls . \
-          && grep 'wait-before-shutdown' \
-          && docker cp ./conf.xml exist:eXist/config/conf.xml
+          && grep 'wait-before-shutdown=' conf.xml \
+          && docker cp ./conf.xml exist:eXist/config/conf.xml \
+          && docker-compose down \
+          && docker-compose up -d \
+          && N=0;until curl -Isf http://127.0.0.1:8080/ | grep 'Jetty' || [ $N -eq 20 ]; do sleep $(( N++ )); done
+          && docker logs exist | grep 'database instance' | grep  'will wait'
        - |
           # Changes made to logger
           # CHECK! the abilty to

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ jobs:
           ]]></text>
           </query>
           EOF
-
        - |
           # manage config files
           # CHECK! the ability to
@@ -140,32 +139,85 @@ jobs:
           ]]></text>
           </query>
           EOF
-          } && docker logs exist 2>/dev/null | grep HELLO
+          } && docker logs exist | grep HELLO
+       - docker-compose down
+     - stage: given commit hash build image from BRANCH build-arg
+       env: DOCKER_TAG=3b195797a
+       install: skip
+       script:
+       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
+       - docker-compose up -d  &>/dev/null
+       - |
+          # CHECK! eXist is starting with health status
+          #  ps cmd should show health status as starting
+          set -eo pipefail
+          docker ps -a | \
+          grep 'exist' | \
+          grep -oP 'health.\sstarting'
+       - |
+          # WAIT! until eXist can be reached
+          # set -eo pipefail
+          N=0
+          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
+            do sleep $(( N++ ))
+          done
+       - |
+          # CHECK! eXist can be reached via http
+          # response header should grep Jetty
+          set -eo pipefail
+          curl -Is http://127.0.0.1:8080/ | \
+          grep 'Jetty'
+       - |
+          # CHECK! docker logs should show server has started
+          set -eo pipefail
+          docker logs exist | \
+          grep -oP '^.+\KServer has started.+'
+       - sleep 30
+       - |
+          # CHECK! healthcheck should register healthy
+          docker ps | \
+          grep -o 'healthy'
+       - docker-compose down
+     - stage: given master branch name build image from BRANCH build-arg
+       env: DOCKER_TAG=master
+       install: skip
+       script:
+       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
+       - docker-compose up -d  &>/dev/null
+       - |
+          # CHECK! eXist is starting with health status
+          #  ps cmd should show health status as starting
+          set -eo pipefail
+          docker ps -a | \
+          grep 'exist' | \
+          grep -oP 'health.\sstarting'
+       - |
+          # WAIT! until eXist can be reached
+          # set -eo pipefail
+          N=0
+          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
+            do sleep $(( N++ ))
+          done
+       - |
+          # CHECK! eXist can be reached via http
+          # response header should grep Jetty
+          set -eo pipefail
+          curl -Is http://127.0.0.1:8080/ | \
+          grep 'Jetty'
+       - |
+          # CHECK! docker logs should show server has started
+          set -eo pipefail
+          docker logs exist | \
+          grep -oP '^.+\KServer has started.+'
+       - sleep 30
+       - |
+          # CHECK! healthcheck should register healthy
+          docker ps | \
+          grep -o 'healthy'
        - docker-compose down
 
-     # - stage: given commit hash build image from BRANCH build-arg
-     #   env: DOCKER_TAG=3b195797a
-     #   install: skip
-     #   script:
-     #   - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
-     #   - docker-compose up -d
-     #   - docker ps -a | grep 'exist'
-     #   - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
-     #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-     #   - docker logs exist | grep 'Server has started'
-     #   - docker-compose down
-     # - stage: given master branch name build image from BRANCH build-arg
-     #   env: DOCKER_TAG=master
-     #   install: skip
-     #   script:
-     #   - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}"  .
-     #   - docker-compose up -d
-     #   - docker ps -a | grep 'exist'
-     #   - while [[ -z "$(curl -I -s -f 'http://127.0.0.1:8080/')" ]] ; do sleep 10 ; done
-     #   - curl -Is http://127.0.0.1:8080/ | grep 'Jetty'
-     #   - docker logs exist | grep 'Server has started'
-     #   - docker-compose down
 
+# TODO maybe
 # a # listing files in config dir
 #  # CHECK! with the exist containers provided config dir,
 #  # a user should be able to list configuration files

--- a/tests/fixtures/t1.xml
+++ b/tests/fixtures/t1.xml
@@ -1,6 +1,6 @@
 <query xmlns="http://exist.sourceforge.net/NS/exist"
  start="1"
- max="99">
+ max="20">
 <text><![CDATA[
 xquery version "3.1";
 string-join(repo:list(), "&#10;")

--- a/tests/fixtures/t1.xml
+++ b/tests/fixtures/t1.xml
@@ -1,8 +1,0 @@
-<query xmlns="http://exist.sourceforge.net/NS/exist"
- start="1"
- max="20">
-<text><![CDATA[
-xquery version "3.1";
-string-join(repo:list(), "&#10;")
-]]></text>
-</query>

--- a/tests/fixtures/t1.xml
+++ b/tests/fixtures/t1.xml
@@ -1,0 +1,8 @@
+<query xmlns="http://exist.sourceforge.net/NS/exist"
+ start="1"
+ max="99">
+<text><![CDATA[
+xquery version "3.1";
+string-join(repo:list(), "&#10;")
+]]></text>
+</query>


### PR DESCRIPTION
This is a rework or .travis.yml  for issue  #27 
See [ last build on travis-ci ](https://travis-ci.com/eXist-db/docker-existdb/builds/83433751)

The following smoke tests are carried out on a running container instance of a freshly minted image
The container is brought up with docker-composer

- [x]  check eXist is starting with health status
- [x]  a timeout wait until eXist can be reached on port 8080
- [x] after sleeping for 30 sec the health-check should register healthy

The following functional test checks are carried out on the first travis job stage
- [x] changing password with client.jar
 checks the ability to
           - invoke client.jar
          - change password
          - query db with new pass
  test: after changing password the is-dba() query call should return true

- [x]  obtain running container eXist 'version'
   checks the ability to
          - invoke a http client (curl)
           - use GET to query the database
    test: the get-version() query, should match the version of the freshly minted built image

- [x] posting requests to rest endpoint url via CURL
   checks the ability to
          - invoke a http client (curl)
         -  query the database by POSTing a query
  test: the list returned from a repo:list() query, should grep 'http://'

 - [x] manage config files
  check the ability to
         - copy a config file from container to local disk
  test: after copying conf.xml the file should exist locally

- [x] persist changed configuration items
  checks the abilty to
         -  alter a config item in a config file on local disk,
         -  copy the altered config file into containers config dir.
         -  stop and start the container
         -  view changed item taking effect in startup logs
 test: the startup log should show altered shutdown time

- [x] log to docker logs
   checks the abilty to
          - call log functions
          -  view results in docker logs
test: eXist log queries output should turn up in docker logs

The main aim was to add run-time functional tests, 
that tests what we have altered in eXist specifically for the container image

#27 issue Items not covered in this pull request 
- [ ] make sure that dashboard is accessible (based on experience healthcheck is not enough for this)
- [ ] Ideally we would check that no ERROR messages appear in the log after startup