### PR TITLE
Green deal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,6 @@ jobs:
        - docker-compose down
      - stage: given commit hash build image from BRANCH build-arg
        env: DOCKER_TAG=449e06c
-       install: skip
        script:
        - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
        - docker-compose up -d  &>/dev/null
@@ -178,7 +177,6 @@ jobs:
        - docker-compose down
      - stage: given master branch name build image from BRANCH build-arg
        env: DOCKER_TAG=master
-       install: skip
        script:
        - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
        - docker-compose up -d  &>/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
      - stage: build docker images
        name: via VERSION tag
        script: docker build --tag existdb/exist-ci-build:${VERSION} --build-arg "VERSION=${VERSION}" .
-     - script: docker build --tag existdb/exist-ci-build:${COMMIT} --build-arg "BRANCH=${COMMIT}" .
-       name: via BRANCH commit
+     - script: docker build --tag existdb/exist-ci-build:${COMMIT} --build-arg "COMMIT=${COMMIT}" .
+       name: via COMMIT hash
      - script:
        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
        - docker build --tag existdb/exist-ci-build:latest --build-arg "BRANCH=${BRANCH}" .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - VERSION=4.6.0
     - COMMIT=449e06c
     - BRANCH=develop
-    - URL=http://127.0.0.1:8080/exist/rest/db
 
 services:
   - docker
@@ -20,13 +19,17 @@ jobs:
        name: via BRANCH commit
      - script:
        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-       - docker build --tag existdb/exist-ci-build:${BRANCH} --build-arg "BRANCH=${BRANCH}" .
+       - docker build --tag existdb/exist-ci-build:latest --build-arg "BRANCH=${BRANCH}" .
        - docker push existdb/exist-ci-build
        name: via BRANCH name
      - stage: test
-       script:
-         - docker run -dit -p 8080:8080 --rm existdb/exist-ci-build:${BRANCH}
-         - docker ps
+       before_install: docker run -dit -p 8080:8080 --rm --name exist existdb/exist-ci-build:latest
+       install:
+         - sudo add-apt-repository ppa:duggan/bats --yes
+         - sudo apt-get update -qq
+         - sudo apt-get install -qq bats
+         - sleep 20
+       script: bats --tap test/*.bats
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,33 @@
 dist: xenial
 language: minimal
-services:
-  - docker
+
 env:
   global:
     - VERSION=4.6.0
     - COMMIT=449e06c
-    - BRANCH=master
+    - BRANCH=develop
     - URL=http://127.0.0.1:8080/exist/rest/db
+
+services:
+  - docker
 
 jobs:
    include:
      - stage: build docker images
        name: via VERSION tag
-       script: docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
-     - script: docker build --tag existdb/existdb:${COMMIT} --build-arg "BRANCH=${COMMIT}" .
+       script: docker build --tag existdb/exist-ci-build:${VERSION} --build-arg "VERSION=${VERSION}" .
+     - script: docker build --tag existdb/exist-ci-build:${COMMIT} --build-arg "BRANCH=${COMMIT}" .
        name: via BRANCH commit
-     - script: docker build --tag existdb/existdb:${BRANCH} --build-arg "BRANCH=${BRANCH}" .
+     - script:
+       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+       - docker build --tag existdb/exist-ci-build:${BRANCH} --build-arg "BRANCH=${BRANCH}" .
+       - docker push existdb/exist-ci-build
        name: via BRANCH name
      - stage: test
-       script: docker ps
+       script:
+         - docker run -dit -p 8080:8080 --rm existdb/exist-ci-build:${BRANCH}
+         - docker ps
 
 
 notifications:
   slack: exist-db:IXzUdqA0n11cnxaDz43ZQgdX
-
-# TODO maybe
-# a # listing files in config dir
-#  # CHECK! with the exist containers provided config dir,
-#  # a user should be able to list configuration files
-#  # that will enable user to alter eXist start up options.
-#  set -eo pipefail
-#  cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
-#  <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
-#  <text><![CDATA[
-#  xquery version '3.1';
-#  let $eXistHome := system:get-exist-home()
-#  let $configDir := concat($eXistHome, '/config')
-#  let $fileList := file:list( configDir )
-#  return
-#   $fileList
-#  ]]></text>
-#  </query>
-#  EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,215 +2,25 @@ dist: xenial
 language: minimal
 services:
   - docker
+env:
+  global:
+    - VERSION=4.6.0
+    - COMMIT=449e06c
+    - BRANCH=master
+    - URL=http://127.0.0.1:8080/exist/rest/db
 
 jobs:
    include:
-     - stage: given ver string build image from VERSION build-arg
-       env:
-        - VERSION=4.6.0
-        - DOCKER_TAG=4.6.0
-        - URL=http://127.0.0.1:8080/exist/rest/db
-       script:
-       - docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" . &>/dev/null
-       - docker-compose up -d  &>/dev/null
-       - |
-          # CHECK! eXist is starting with health status
-          #  ps cmd should show health status as starting
-          set -eo pipefail
-          docker ps -a | \
-          grep 'exist' | \
-          grep -oP 'health.\sstarting'
-       - |
-          # WAIT! until eXist can be reached
-          # set -eo pipefail
-          N=0
-          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
-            do sleep $(( N++ ))
-          done
-       - |
-          # CHECK! eXist can be reached via http
-          # response header should grep Jetty
-          set -eo pipefail
-          curl -Is http://127.0.0.1:8080/ | \
-          grep 'Jetty'
-       - |
-          # CHECK! docker logs should show server has started
-          set -eo pipefail
-          docker logs exist | \
-          grep -oP '^.+\KServer has started.+'
-       - sleep 30
-       - |
-          # CHECK! healthcheck should register healthy
-          docker ps | \
-          grep -o 'healthy'
-       - |
-          # changing password with client.jar
-          # CHECK! the ability to
-          #  - invoke client.jar
-          #  - change password
-          #  - query db with new pass
-          # after changing password the is-dba() query call should return true
-          set -eo pipefail
-          docker exec exist java -jar start.jar client -q -u admin -P '' \
-          -x 'sm:passwd("admin", "nimda")' 2>/dev/null
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep 'true'
-          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
-          <text><![CDATA[
-          xquery version '3.1';
-          sm:is-dba(xmldb:get-current-user())
-          ]]></text>
-          </query>
-          EOF
-       - |
-          # obtain running container eXist 'version'
-          # # http GET request to rest endpoint url via CURL
-          # CHECK! the ability to
-          #  - invoke a http client (curl)
-          #  - use GET to query the database
-          #  the get-version() query,
-          #  should match the version of the freshly minted built image
-          set -eo pipefail
-          curl -s -u 'admin:nimda' "$URL?_query=system:get-version()&_wrap=no" | \
-          grep "$VERSION"
-       - |
-          # posting requests to rest endpoint url via CURL
-          # CHECK! the ability to
-          #  - invoke a http client (curl)
-          #  - to query the database by POSTing a query
-          #
-          #  the list returned from a repo:list() query,
-          #  should grep 'http://'
-          set -eo pipefail
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL" | grep 'http://'
-          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
-          <text><![CDATA[
-          xquery version '3.1';
-          string-join(repo:list(), '&#10;')
-          ]]></text>
-          </query>
-          EOF
-       - |
-          # manage config files
-          # CHECK! the ability to
-          # - copy a config file from container to local disk
-          # after copying conf.xml the file should exist locally
-          set -eo pipefail
-          docker cp exist:exist/config/conf.xml ./conf.xml \
-          && [[ -e ./conf.xml ]] && ls -l ./conf.xml
-       - |
-          # persist changed configuration items
-          # CHECK! the abilty to
-          #  - alter a config item in a config file on local disk,
-          #  - copy the altered config file into containers config dir.
-          #  - stop and start the container
-          #  - view changed item taking effect in startup logs
-          #
-          # The startup log should show altered shutdown time
-          set -eo pipefail
-          sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml
-          docker cp ./conf.xml exist:exist/config/conf.xml
-          docker-compose down &>/dev/null
-          docker-compose up -d &>/dev/null
-          N=0
-          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
-            do sleep $(( N++ ))
-          done
-          docker logs exist | grep '60,000 ms during shutdown'
-       - |
-          # log to docker logs
-          # CHECK! the abilty to
-          # - call log functions
-          # - view results in docker logs
-          #
-          # eXist log queries should turn up in docker logs
-          {
-          cat <<EOF | curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @- "$URL"
-          <query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
-          <text><![CDATA[
-          xquery version '3.1';
-          (
-          util:log-system-out('HELLO SYSTEM-OUT!'),
-          util:log-system-err('HELLO SYSTEM-ERR!'),
-          util:log('INFO', 'HELLO logged INFO!'),
-          util:log('WARN', 'HELLO logged WARN' )
-          )
-          ]]></text>
-          </query>
-          EOF
-          } && docker logs exist | grep HELLO
-       - docker-compose down
-     - stage: given commit hash build image from BRANCH build-arg
-       env: DOCKER_TAG=449e06c
-       script:
-       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
-       - docker-compose up -d  &>/dev/null
-       - |
-          # CHECK! eXist is starting with health status
-          #  ps cmd should show health status as starting
-          set -eo pipefail
-          docker ps -a | \
-          grep 'exist' | \
-          grep -oP 'health.\sstarting'
-       - |
-          # WAIT! until eXist can be reached
-          # set -eo pipefail
-          N=0
-          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
-            do sleep $(( N++ ))
-          done
-       - |
-          # CHECK! eXist can be reached via http
-          # response header should grep Jetty
-          set -eo pipefail
-          curl -Is http://127.0.0.1:8080/ | \
-          grep 'Jetty'
-       - |
-          # CHECK! docker logs should show server has started
-          set -eo pipefail
-          docker logs exist | \
-          grep -oP '^.+\KServer has started.+'
-       - sleep 30
-       - |
-          # CHECK! healthcheck should register healthy
-          docker ps | \
-          grep -o 'healthy'
-       - docker-compose down
-     - stage: given master branch name build image from BRANCH build-arg
-       env: DOCKER_TAG=master
-       script:
-       - docker build --tag existdb/existdb:${DOCKER_TAG} --build-arg "BRANCH=${DOCKER_TAG}" . &>/dev/null
-       - docker-compose up -d  &>/dev/null
-       - |
-          # CHECK! eXist is starting with health status
-          #  ps cmd should show health status as starting
-          set -eo pipefail
-          docker ps -a | \
-          grep 'exist' | \
-          grep -oP 'health.\sstarting'
-       - |
-          # WAIT! until eXist can be reached
-          # set -eo pipefail
-          N=0
-          until curl -Isf http://127.0.0.1:8080/ 2>/dev/null | grep 'Jetty' || [ $N -eq 20 ]
-            do sleep $(( N++ ))
-          done
-       - |
-          # CHECK! eXist can be reached via http
-          # response header should grep Jetty
-          set -eo pipefail
-          curl -Is http://127.0.0.1:8080/ | \
-          grep 'Jetty'
-       - |
-          # CHECK! docker logs should show server has started
-          set -eo pipefail
-          docker logs exist | \
-          grep -oP '^.+\KServer has started.+'
-       - sleep 30
-       - |
-          # CHECK! healthcheck should register healthy
-          docker ps | \
-          grep -o 'healthy'
-       - docker-compose down
+     - stage: build docker images
+       name: via VERSION tag
+       script: docker build --tag existdb/existdb:${VERSION} --build-arg "VERSION=${VERSION}" .
+     - script: docker build --tag existdb/existdb:${COMMIT} --build-arg "BRANCH=${COMMIT}" .
+       name: via BRANCH commit
+     - script: docker build --tag existdb/existdb:${BRANCH} --build-arg "BRANCH=${BRANCH}" .
+       name: via BRANCH name
+     - stage: test
+       script: docker ps
+
 
 notifications:
   slack: exist-db:IXzUdqA0n11cnxaDz43ZQgdX

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,6 @@ RUN mkdir -p $EXIST_MIN \
   && mkdir -p $EXIST_MIN/extensions/expath \
   && mkdir -p $EXIST_MIN/extensions/indexes/lucene \
   && mkdir -p $EXIST_MIN/extensions/webdav \
-  && mkdir -p $EXIST_MIN/extensions/xprocxq/main \
   && mkdir -p $EXIST_MIN/extensions/xqdoc \
   && cp -r extensions/betterform/main/lib $EXIST_MIN/extensions/betterform/main \
   && cp -r extensions/contentextraction/lib $EXIST_MIN/extensions/contentextraction \
@@ -113,7 +112,6 @@ RUN mkdir -p $EXIST_MIN \
   && cp -r extensions/exquery/restxq/lib $EXIST_MIN/extensions/exquery/restxq \
   && cp -r extensions/indexes/lucene/lib $EXIST_MIN/extensions/indexes/lucene \
   && cp -r extensions/webdav/lib $EXIST_MIN/extensions/webdav \
-  && cp -r extensions/xprocxq/main/lib $EXIST_MIN/extensions/xprocxq/main \
   && cp -r extensions/xqdoc/lib $EXIST_MIN/extensions/xqdoc \
   && echo ' - copy ivy libs' \
   && for dir in extensions/modules/**/lib; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # @arg BRANCH - branch can be a
 # - branch name e.g release,develop, name-of-branch
 # - tagged commit e.g. eXist-4.3.1
-# - any commit hash ( short or long )
+# @arg COMMIT - can be any commit hash ( short or long )
 #   e.g 3b19579, 3b195797a2c2f35913891412859b06d94f189229
 # @arg BUILD_DATE
 # @arg VCS_REF
@@ -29,6 +29,7 @@ FROM openjdk:8-jdk-slim as builder
 
 ARG VERSION
 ARG BRANCH=develop
+ARG COMMIT
 ENV EXIST_MIN  "/exist"
 ENV EXIST_MAX  "/usr/local/exist"
 
@@ -43,12 +44,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   liblcms2-2 \
   libpng16-16 \
   ttf-dejavu-core \
-  && echo " - cloning eXist" \
-  && git clone --progress https://github.com/exist-db/exist.git \
-  && cd $EXIST_MAX \
   && if [ -n "${VERSION}" ] ; then export BRANCH=eXist-${VERSION}; fi \
-  && echo " - checking out $BRANCH" \
-  && git checkout $BRANCH \
+  && echo " - cloning eXist" \
+  && if [ -n "${COMMIT}" ] ; then git clone --depth=2000 --progress https://github.com/exist-db/exist.git \
+  && cd $EXIST_MAX \
+  && git checkout ${COMMIT}; \
+  else git clone --depth=1 --branch ${BRANCH} --progress https://github.com/exist-db/exist.git ; fi \
+  && cd $EXIST_MAX \
   && ./build.sh \
   && cd $EXIST_MAX && ./build.sh
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository holds the source files for building a minimal docker image of th
 
 ## Requirements
 *   [Docker](https://www.docker.com): `18-stable`
+For test development only:
+*   [bats-core](https://github.com/bats-core/bats-core): `1.1.0`
 
 ## How to use
 Pre-build images are available on [DockerHub](https://hub.docker.com/r/existdb/existdb/). There are two channels:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-eXist
 minimal exist-db docker image with FO support
 
-[![Build Status](https://travis-ci.com/eXist-db/docker-existdb.svg?branch=master)](https://travis-ci.com/eXist-db/docker-existdb)
+[![Build Status](https://travis-ci.com/eXist-db/docker-existdb.svg?branch=develop)](https://travis-ci.com/eXist-db/docker-existdb)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ace7cb88e9934b5f9ae772e981db177f)](https://www.codacy.com/app/eXist-db/docker-existdb?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=eXist-db/docker-existdb&amp;utm_campaign=Badge_Grade)
 [![License](https://img.shields.io/badge/license-AGPL%203.1-orange.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
 [![](https://images.microbadger.com/badges/image/existdb/existdb.svg)](https://microbadger.com/images/existdb/existdb "Get your own image badge on microbadger.com")

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository holds the source files for building a minimal docker image of th
 
 ## Requirements
 *   [Docker](https://www.docker.com): `18-stable`
+
 For test development only:
 *   [bats-core](https://github.com/bats-core/bats-core): `1.1.0`
 

--- a/test/01-connect-spec.bats
+++ b/test/01-connect-spec.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# Basic start-up and connection tests
+@test "jvm responds from client" {
+  run docker exec exist java -version
+  [ "$status" -eq 0 ]
+}
+
+@test "eXist can be reached via http" {
+  result=$(curl -Is http://127.0.0.1:8080/ | grep -o 'Jetty')
+  [ "$result" == 'Jetty' ]
+}
+
+@test "eXist reports healthy to docker" {
+  result=$(docker ps | grep -o 'healthy')
+  [ "$result" == 'healthy' ]
+}
+
+@test "eXist logs show clean start" {
+  result=$(docker logs exist | grep -o 'Server has started')
+  [ "$result" == 'Server has started' ]
+}
+
+@test "logs are error free" {
+  skip
+  run docker logs exist | grep -o 'ERROR'
+  [ "$status" -eq 1 ]
+}

--- a/test/02-config-spec.bats
+++ b/test/02-config-spec.bats
@@ -12,8 +12,6 @@
 }
 
 @test "create modified image" {
-  # run docker pull existdb/exist-ci-build:develop
-  # [ "$status" -eq 0 ]
   run docker create --name ex-mod -p 9090:8080 existdb/exist-ci-build:latest
   [ "$status" -eq 0 ]
   run docker cp ./conf.xml ex-mod:exist/config/conf.xml

--- a/test/02-config-spec.bats
+++ b/test/02-config-spec.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+# Tests for modifying eXist's configuration files
+@test "copy configuration file from container to disk" {
+  run docker cp exist:exist/config/conf.xml ./conf.xml && [[ -e ./conf.xml ]] && ls -l ./conf.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "modify the copied config file" {
+  run sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "create modified image" {
+  # run docker pull existdb/exist-ci-build:develop
+  # [ "$status" -eq 0 ]
+  run docker create --name ex-mod -p 9090:8080 existdb/exist-ci-build:latest
+  [ "$status" -eq 0 ]
+  run docker cp ./conf.xml ex-mod:exist/config/conf.xml
+  [ "$status" -eq 0 ]
+  run docker start ex-mod
+  [ "$status" -eq 0 ]
+}
+
+@test "modification is applied in container" {
+  # Make sure container is running
+  result=$(docker ps | grep -o 'ex-mod')
+  [ "$result" == 'ex-mod' ]
+  sleep 30
+  result=$(docker logs ex-mod | grep -o "60,000 ms during shutdown")
+  [ "$result" == '60,000 ms during shutdown' ]
+}
+
+@test "teardown modified image" {
+  run docker stop ex-mod
+  [ "$status" -eq 0 ]
+  [ "$output" == "ex-mod" ]
+  run docker rm ex-mod
+  [ "$status" -eq 0 ]
+  [ "$output" == "ex-mod" ]
+  run rm ./conf.xml
+  [ "$status" -eq 0 ]
+  run rm ./conf.xml.bak
+  [ "$status" -eq 0 ]
+}
+
+@test "log queries to sytem are visible to docker" {
+  run docker exec exist java -jar start.jar client -q -u admin -P '' -x 'util:log-system-out("HELLO SYSTEM-OUT")'
+  [ "$status" -eq 0 ]
+  result=$(docker logs exist | grep -o "HELLO SYSTEM-OUT" | head -1)
+  [ "$result" == "HELLO SYSTEM-OUT" ]
+}
+
+@test "regular log queries are visible to docker" {
+  run docker exec exist java -jar start.jar client -q -u admin -P '' -x 'util:log("INFO", "HELLO logged INFO")'
+  [ "$status" -eq 0 ]
+  result=$(docker logs exist | grep -o "HELLO logged INFO" | head -1)
+  [ "$result" == "HELLO logged INFO" ]
+}

--- a/test/03-xquery-spec.bats
+++ b/test/03-xquery-spec.bats
@@ -18,7 +18,7 @@
   echo '# ' $output >&3
 }
 
-@test "POST check version" {
+@test "POST list repo query" {
   result=$(curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @test/repo-list.xml http://127.0.0.1:8080/exist/rest/db | grep -o 'http://' | head -1)
   [ "$result" == 'http://' ]
 }

--- a/test/03-xquery-spec.bats
+++ b/test/03-xquery-spec.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+# Tests that execute xquery via start.jar
+@test "Change admin password" {
+  run docker exec exist java -jar start.jar client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")'
+  [ "$status" -eq 0 ]
+}
+
+# Tests that use rest endpoint, this might be disabled by default soon
+@test "confirm new password" {
+  result=$(curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @test/dba-xq.xml http://127.0.0.1:8080/exist/rest/db | grep 'true' | head -1)
+  [ "$result" == 'true' ]
+}
+
+@test "GET version via rest" {
+  run curl -s -u 'admin:nimda' "http://127.0.0.1:8080/exist/rest/db?_query=system:get-version()&_wrap=no"
+  [ "$status" -eq 0 ]
+  echo '# ' $output >&3
+}
+
+@test "POST check version" {
+  result=$(curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @test/repo-list.xml http://127.0.0.1:8080/exist/rest/db | grep -o 'http://' | head -1)
+  [ "$result" == 'http://' ]
+}
+
+@test "teardown revert changes" {
+  run docker exec exist java -jar start.jar client -q -u admin -P 'nimda' -x 'sm:passwd("admin", "")'
+  [ "$status" -eq 0 ]
+}

--- a/test/dba-xq.xml
+++ b/test/dba-xq.xml
@@ -1,0 +1,6 @@
+<query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+<text><![CDATA[
+xquery version '3.1';
+sm:is-dba(xmldb:get-current-user())
+]]></text>
+</query>

--- a/test/repo-list.xml
+++ b/test/repo-list.xml
@@ -1,0 +1,6 @@
+<query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+<text><![CDATA[
+xquery version '3.1';
+string-join(repo:list(), '&#10;')
+]]></text>
+</query>


### PR DESCRIPTION
!! Do not merge until #59 is merged !!

This uses shallow clones `depth=1` in the builder stage for `branch` and `tag` based builds, which makes them faster,  leads to less congested airwaves, and about 600mb smaller builder images on disk.

`commit` based builds are `depth=2000` which is i think the maximum of what we can sensibly expect to work and still better than having 14000 commits and counting in the builder. If git in the future supports cloning via commitish we can further simplify the logic. 