### PR TITLE
Green hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
      - stage: build docker images
        name: via VERSION tag
        script: docker build --tag existdb/exist-ci-build:${VERSION} --build-arg "VERSION=${VERSION}" .
-     - script: docker build --tag existdb/exist-ci-build:${COMMIT} --build-arg "BRANCH=${COMMIT}" .
-       name: via BRANCH commit
+     - script: docker build --tag existdb/exist-ci-build:${COMMIT} --build-arg "COMMIT=${COMMIT}" .
+       name: via COMMIT hash
      - script:
        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
        - docker build --tag existdb/exist-ci-build:latest --build-arg "BRANCH=${BRANCH}" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,6 @@ RUN mkdir -p $EXIST_MIN \
   && mkdir -p $EXIST_MIN/extensions/expath \
   && mkdir -p $EXIST_MIN/extensions/indexes/lucene \
   && mkdir -p $EXIST_MIN/extensions/webdav \
-  && mkdir -p $EXIST_MIN/extensions/xprocxq/main \
   && mkdir -p $EXIST_MIN/extensions/xqdoc \
   && cp -r extensions/betterform/main/lib $EXIST_MIN/extensions/betterform/main \
   && cp -r extensions/contentextraction/lib $EXIST_MIN/extensions/contentextraction \
@@ -113,7 +112,6 @@ RUN mkdir -p $EXIST_MIN \
   && cp -r extensions/exquery/restxq/lib $EXIST_MIN/extensions/exquery/restxq \
   && cp -r extensions/indexes/lucene/lib $EXIST_MIN/extensions/indexes/lucene \
   && cp -r extensions/webdav/lib $EXIST_MIN/extensions/webdav \
-  && cp -r extensions/xprocxq/main/lib $EXIST_MIN/extensions/xprocxq/main \
   && cp -r extensions/xqdoc/lib $EXIST_MIN/extensions/xqdoc \
   && echo ' - copy ivy libs' \
   && for dir in extensions/modules/**/lib; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # @arg BRANCH - branch can be a
 # - branch name e.g release,develop, name-of-branch
 # - tagged commit e.g. eXist-4.3.1
-# - any commit hash ( short or long )
+# @arg COMMIT - can be any commit hash ( short or long )
 #   e.g 3b19579, 3b195797a2c2f35913891412859b06d94f189229
 # @arg BUILD_DATE
 # @arg VCS_REF
@@ -29,6 +29,7 @@ FROM openjdk:8-jdk-slim as builder
 
 ARG VERSION
 ARG BRANCH=develop
+ARG COMMIT
 ENV EXIST_MIN  "/exist"
 ENV EXIST_MAX  "/usr/local/exist"
 
@@ -43,12 +44,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   liblcms2-2 \
   libpng16-16 \
   ttf-dejavu-core \
-  && echo " - cloning eXist" \
-  && git clone --progress https://github.com/exist-db/exist.git \
-  && cd $EXIST_MAX \
   && if [ -n "${VERSION}" ] ; then export BRANCH=eXist-${VERSION}; fi \
-  && echo " - checking out $BRANCH" \
-  && git checkout $BRANCH \
+  && echo " - cloning eXist" \
+  && if [ -n "${COMMIT}" ] ; then git clone --depth=2000 --progress https://github.com/exist-db/exist.git \
+  && cd $EXIST_MAX \
+  && git checkout ${COMMIT}; \
+  else git clone --depth=1 --branch ${BRANCH} --progress https://github.com/exist-db/exist.git ; fi \
+  && cd $EXIST_MAX \
   && ./build.sh \
   && cd $EXIST_MAX && ./build.sh
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-eXist
 minimal exist-db docker image with FO support
 
-[![Build Status](https://travis-ci.com/eXist-db/docker-existdb.svg?branch=master)](https://travis-ci.com/eXist-db/docker-existdb)
+[![Build Status](https://travis-ci.com/eXist-db/docker-existdb.svg?branch=develop)](https://travis-ci.com/eXist-db/docker-existdb)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ace7cb88e9934b5f9ae772e981db177f)](https://www.codacy.com/app/eXist-db/docker-existdb?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=eXist-db/docker-existdb&amp;utm_campaign=Badge_Grade)
 [![License](https://img.shields.io/badge/license-AGPL%203.1-orange.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
 [![](https://images.microbadger.com/badges/image/existdb/existdb.svg)](https://microbadger.com/images/existdb/existdb "Get your own image badge on microbadger.com")


### PR DESCRIPTION
This uses shallow clones depth=1 in the builder stage for branch and tag based builds, which makes them faster, leads to less congested airwaves, and about 600mb smaller builder images on disk.

commit based builds are depth=2000 which is i think the maximum of what we can sensibly expect to work and still better than having 14000 commits and counting in the builder. If git in the future supports cloning via commitish we can further simplify the logic.

readme changes

hotfix for 4.7.0 changes which are on develop, will require a second PR from `develop` into `master` along the release of 4.7.0.