### PR TITLE
fix(gcr): switch sun.jnu encoding back to UTF-8 inside gcr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,7 @@ ARG MAX_BROKER
 # also sets default values to previous two arguments
 ENV JAVA_TOOL_OPTIONS \
   -Dfile.encoding=UTF8 \
+  -Dsun.jnu.encoding=UTF-8 \
   -Djava.awt.headless=true \
   -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M \
   -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20} \


### PR DESCRIPTION
backport of #74 should be merged despite CI failures, those will go away once 4.7.0 is released.